### PR TITLE
Exporting symbols for UPingIP

### DIFF
--- a/Source/Ping/Public/PingIP.h
+++ b/Source/Ping/Public/PingIP.h
@@ -39,7 +39,7 @@ typedef class MacLinuxPingThread PingThreadType;
 *	Container class for ping functionality.  Acts as interface between blueprint and ping code
 */
 UCLASS(Blueprintable, BlueprintType, Config = Game)
-class UPingIP : public UObject
+class PING_API UPingIP : public UObject
 {
 	GENERATED_UCLASS_BODY()
 


### PR DESCRIPTION
Adding PING_API macro to the UPingIP class declaration so that it will be exported and can be used from code.
