### PR TITLE
change TargetInfo to ReadOnlyTargetRules

### DIFF
--- a/Source/Ping/Ping.Build.cs
+++ b/Source/Ping/Ping.Build.cs
@@ -4,7 +4,7 @@ using UnrealBuildTool;
 
 public class Ping : ModuleRules
 {
-	public Ping(TargetInfo Target)
+	public Ping(ReadOnlyTargetRules Target) : base(Target)
 	{
 		
 		PublicIncludePaths.AddRange(


### PR DESCRIPTION
This change removes the warning when compiling the plugin for engine version 4.16 and above.