### PR TITLE
UE 4.25 + Mac/Linux fix

### DIFF
--- a/Source/Ping/Ping.Build.cs
+++ b/Source/Ping/Ping.Build.cs
@@ -6,7 +6,8 @@ public class Ping : ModuleRules
 {
 	public Ping(ReadOnlyTargetRules Target) : base(Target)
 	{
-		
+		PrivatePCHHeaderFile = "Private/PingPrivatePCH.h";
+        
 		PublicIncludePaths.AddRange(
 			new string[] {
 				"Ping/Public"

--- a/Source/Ping/Private/MacLinuxPingThread.cpp
+++ b/Source/Ping/Private/MacLinuxPingThread.cpp
@@ -126,7 +126,7 @@ FString MacLinuxPingThread::WhichPing() const
 		UE_LOG(LogPing, VeryVerbose, TEXT("Read in %d characters from 'which' cout."), stdOut.Len());
 
         processedOutput = stdOut;
-        processedOutput.TrimTrailing();
+        processedOutput = processedOutput.TrimEnd();
         int32 lastNewline;
         if (processedOutput.FindLastChar(TEXT('\n'), lastNewline))
         {

--- a/Source/Ping/Private/MacLinuxPingThread.cpp
+++ b/Source/Ping/Private/MacLinuxPingThread.cpp
@@ -155,6 +155,9 @@ FString MacLinuxPingThread::WhichPing() const
 
 uint32 MacLinuxPingThread::Run()
 {
+    int32* PingTime = -1;
+    int32* ThreadComplete;
+    
 //    FString pingPath = WhichPing();
 //
 //	if (pingPath.Len() == 0)

--- a/Source/Ping/Public/IPingThread.h
+++ b/Source/Ping/Public/IPingThread.h
@@ -14,6 +14,8 @@ DECLARE_STATS_GROUP(TEXT("PingPlugin"), STATGROUP_PingPlugin, STATCAT_Advanced);
 class IPingThread : public FRunnable
 {
 protected:
+	volatile int32* ThreadComplete;
+	volatile int32* PingTime;
 	FString const Hostname;
 private:
 	TWeakObjectPtr<UPingIP> PingOperation; // Only access from Game Thread.

--- a/Source/Ping/Public/IPingThread.h
+++ b/Source/Ping/Public/IPingThread.h
@@ -14,8 +14,6 @@ DECLARE_STATS_GROUP(TEXT("PingPlugin"), STATGROUP_PingPlugin, STATCAT_Advanced);
 class IPingThread : public FRunnable
 {
 protected:
-	volatile int32* ThreadComplete;
-	volatile int32* PingTime;
 	FString const Hostname;
 private:
 	TWeakObjectPtr<UPingIP> PingOperation; // Only access from Game Thread.


### PR DESCRIPTION
- Reintroduced missing variables `ThreadComplete` and `PingTime` used in `MacLinuxPingThread.cpp`, which were preventing compilation on Mac and Linux.
- Replaced use of `FString::TrimEnd()` (which got removed from the engine) with `FString::TrimTrailing()`, also preventing compilation on Mac and Linux 
- Added `PrivatePCHHeaderFile` explicit declaration in `Ping.Build.cs`, as needed since UE 4.21.

Tested and working on UE 4.25 on Windows and MacOS.
This fixes issue #6 as well. 