### PR TITLE
Fixed Mac/Linux pointers init

### DIFF
--- a/Source/Ping/Private/MacLinuxPingThread.cpp
+++ b/Source/Ping/Private/MacLinuxPingThread.cpp
@@ -155,8 +155,8 @@ FString MacLinuxPingThread::WhichPing() const
 
 uint32 MacLinuxPingThread::Run()
 {
-    int32* PingTime = -1;
-    int32* ThreadComplete;
+    int32* PingTime = new int32(-1);
+    int32* ThreadComplete = new int32;
     
 //    FString pingPath = WhichPing();
 //


### PR DESCRIPTION
I overlooked pointers initialization of the previously missing variables for Mac/Linux in my last pull request, sorry about that.
That's fixed.